### PR TITLE
Support for defining super-repo dependencies in the source code, fixes # 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
   - "2.10.7"
 jdk:
   - oraclejdk7
-script: sbt ++${TRAVIS_SCALA_VERSION} test
+script: sbt ++${TRAVIS_SCALA_VERSION} test publishM2 scripted
 env:
   global:
     - secure: "adngy4wHe+DLnkLW0K7S8KFe+GR2mTMHx3VPs4YFooXSkJlRZMzhMzd2nJN0VNb2U7zkIrtLvsykLGIaeKF3u02iheHt3RCpRoKmxOjAkFXSRm6V7Z1J+EMVHqAG/72L2P2KkjJEaXrQqE3yG6e6elRk+qp2V3zKpQ6E5sS/g3c="

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,6 +1,6 @@
 
 
-
+import sbt.ScriptedPlugin._
 import sbt._
 import Keys._
 import java.io._
@@ -78,7 +78,12 @@ object MechaBuild extends Build {
   lazy val mecha = Project(
     "mecha",
     file("."),
-    settings = mechaSettings
+    settings = mechaSettings ++ scriptedSettings ++ Seq(
+      scriptedLaunchOpts := { scriptedLaunchOpts.value ++
+        Seq("-Dplugin.version=" + version.value)
+      },
+      scriptedBufferLog := false
+    )
   )
 
 }

--- a/project/scripted.sbt
+++ b/project/scripted.sbt
@@ -1,0 +1,2 @@
+
+libraryDependencies += { "org.scala-sbt" % "scripted-plugin" % sbtVersion.value }

--- a/src/main/scala/org/stormenroute/mecha/MechaProjectBuild.scala
+++ b/src/main/scala/org/stormenroute/mecha/MechaProjectBuild.scala
@@ -1,0 +1,122 @@
+package org.stormenroute.mecha
+
+import sbt._
+
+/**
+  * Optionally mixed into projects builds within a super-repository
+  * for source-level dependencies.
+  */
+trait MechaProjectBuild {
+
+  /** Dirty hack because sbt does not expose BuildUnit.localBase easily.
+    */
+  def buildBase: File = {
+    val currDir = file(".")
+    if (currDir.getAbsoluteFile.getParentFile.getName == repoName) currDir
+    else file(repoName)
+  }
+
+  def repoName: String
+
+  /** Location of the repository configuration in the super-repo.
+    */
+  def repositoriesPath: String = "../repos.conf"
+
+  final def repositoriesFile: File = new File(buildBase, repositoriesPath)
+
+  /** Holds repository configuration if repo is checked out within a super-repo.
+    */
+  lazy val repositories: Option[collection.Map[String, Repo]] = {
+    if (repositoriesFile.exists) {
+      Some(ConfigParsers.reposFromHocon(repositoriesFile))
+    }
+    else None
+  }
+
+  /** List of super-repo projects dependencies.
+    *
+    * {{{
+    * Seq(
+    *   ("repo-1", "project-id-1", Some("test"))
+    *   ("repo-1", "project-id-2", None)
+    *   ("repo-2", "project-id-3", None)
+    * )
+    * }}}
+    */
+  def superRepoProjectsDependencies: Seq[(String, String, Option[String])]
+
+  /** List of project runtime dependencies.
+    */
+  def runtimeDependencies: Def.Initialize[Seq[ModuleID]]
+
+  /** Maps project dependencies in the build to their projects within a super-repo.
+    *
+    * {{{
+    * Seq(
+    *   dependency1 -> ("repo-1", "project-id-1", Some("test"))
+    *   dependency2 -> ("repo-1", "project-id-2", None)
+    *   dependency3 -> ("repo-2", "project-id-3", None)
+    * )
+    * }}}
+    */
+  def superRepoDependenciesMappings: Def.Initialize[Seq[(ModuleID, (String, String, Option[String]))]] = Def.setting {
+    val deps = runtimeDependencies.value
+
+    superRepoProjectsDependencies.collect {
+      case projDep@(_, proj, _) if deps.exists(_.name == proj) =>
+        val dep = deps.find(_.name == proj).get
+
+        (dep, projDep)
+    }
+  }
+
+  /** Resolves the artifact dependencies based on the super-repo.
+    *
+    * @return dependencies that can be resolved through projects in super-repo or empty list
+    */
+  def excludeSuperRepoDependencies: Def.Initialize[Seq[ModuleID]] = Def.setting {
+    repositories match {
+      case None => Nil
+      case Some(repos) => superRepoDependenciesMappings.value.collect {
+        case (dep, (repo, _, _)) if repoDirExists(repos, repo) => dep
+      }
+    }
+  }
+
+  private def repoDirExists(repos: collection.Map[String, Repo], repo: String): Boolean = {
+    new File(buildBase, getRepoDir(repos, repo)).exists
+  }
+
+  private def getRepoDir(repos: collection.Map[String, Repo], repo: String) = {
+    repos.get(repo) match {
+      case Some(r) => s"../${r.dir}"
+      case None =>
+        throw new IllegalArgumentException(s"Repo '$repo' not found, super-repositories: $repos")
+    }
+  }
+
+  implicit class ProjectOps(p: Project) {
+
+    /**
+      * Returns the version of the project depending directly on projects in the super-repository,
+      * if a super-repository is present.
+      */
+    def dependsOnSuperRepo: Project = repositories match {
+      case None => p
+      case Some(repos) =>
+        superRepoProjectsDependencies.filter { case (repo, _, _) =>
+          repoDirExists(repos, repo)
+        }.foldLeft(p) { (proj, dep) =>
+          val (repo, project, configuration) = dep
+          val other = ProjectRef(
+            uri(getRepoDir(repos, repo)),
+            project
+          )
+          configuration match {
+            case Some(c) => proj.dependsOn(other % c)
+            case None => proj.dependsOn(other)
+          }
+        }
+    }
+  }
+}

--- a/src/sbt-test/mecha/mecha-super-repo/examples-application/build.sbt
+++ b/src/sbt-test/mecha/mecha-super-repo/examples-application/build.sbt
@@ -1,0 +1,15 @@
+
+lazy val `examples-application` = ExamplesApplicationBuild.examplesApplication
+  .settings(
+    assemblyJarName in assembly := "examples-application.jar",
+    TaskKey[Unit]("check") := {
+      val process = sbt.Process("java", Seq(
+        "-jar", (crossTarget.value / (assemblyJarName in assembly).value).toString)
+      )
+      val out = (process!!).trim
+      if (out != "125") {
+        sys.error("unexpected output: " + out)
+      }
+      ()
+    }
+  )

--- a/src/sbt-test/mecha/mecha-super-repo/examples-application/project/Build.scala
+++ b/src/sbt-test/mecha/mecha-super-repo/examples-application/project/Build.scala
@@ -1,0 +1,42 @@
+
+import org.stormenroute.mecha._
+import sbt.Keys._
+import sbt._
+
+object ExamplesApplicationBuild extends MechaProjectBuild {
+
+  lazy val examplesApplicationSettings = Defaults.coreDefaultSettings ++
+    MechaRepoPlugin.defaultSettings ++ Seq(
+    name := "examples-application",
+    scalaVersion := "2.11.4",
+    version := "0.1.0-SNAPSHOT",
+    organization := "com.storm-enroute",
+
+    // include dependencies as usual
+    libraryDependencies ++= runtimeDependencies.value,
+
+    // AT THE END of settings
+    // exclude dependencies based on super-repo, if any
+    libraryDependencies --= excludeSuperRepoDependencies.value
+  )
+
+  // put super-repo projects dependencies here
+  val superRepoProjectsDependencies: Seq[(String, String, Option[String])] = Seq(
+    // (repo, project, configuration)
+    ("examples-core-utils", "examples-core-utils", None)
+  )
+
+  // you can put ALL usual project dependencies here
+  val runtimeDependencies: Def.Initialize[Seq[ModuleID]] = Def.setting(Seq(
+    Def.setting("com.storm-enroute" %% "examples-core-utils" % "0.1.0-SNAPSHOT").value,
+    Def.setting("org.scalatest" %% "scalatest" % "3.0.1" % "test").value
+  ))
+
+  val repoName = "examples-application"
+
+  lazy val examplesApplication: Project = Project(
+    "examples-application",
+    file("."),
+    settings = examplesApplicationSettings
+  ) dependsOnSuperRepo
+}

--- a/src/sbt-test/mecha/mecha-super-repo/examples-application/project/assembly.sbt
+++ b/src/sbt-test/mecha/mecha-super-repo/examples-application/project/assembly.sbt
@@ -1,0 +1,2 @@
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/src/sbt-test/mecha/mecha-super-repo/examples-application/project/build.properties
+++ b/src/sbt-test/mecha/mecha-super-repo/examples-application/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.17

--- a/src/sbt-test/mecha/mecha-super-repo/examples-application/project/plugins.sbt
+++ b/src/sbt-test/mecha/mecha-super-repo/examples-application/project/plugins.sbt
@@ -1,0 +1,8 @@
+
+resolvers += "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository"
+
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.storm-enroute" % "mecha" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/mecha/mecha-super-repo/examples-application/src/main/scala/org/stormenroute/mecha/App.scala
+++ b/src/sbt-test/mecha/mecha-super-repo/examples-application/src/main/scala/org/stormenroute/mecha/App.scala
@@ -1,0 +1,8 @@
+package org.stormenroute.mecha
+
+object App {
+
+  def main(args: Array[String]): Unit = {
+    println(Utils.multiply(5))
+  }
+}

--- a/src/sbt-test/mecha/mecha-super-repo/examples-core-utils/build.sbt
+++ b/src/sbt-test/mecha/mecha-super-repo/examples-core-utils/build.sbt
@@ -1,0 +1,8 @@
+
+lazy val `examples-core-utils` = (project in file("."))
+  .settings(
+    name := "examples-core-utils",
+    scalaVersion := "2.11.4",
+    version := "0.1.0-SNAPSHOT",
+    organization := "com.storm-enroute"
+  )

--- a/src/sbt-test/mecha/mecha-super-repo/examples-core-utils/src/main/scala/org/stormenroute/mecha/Utils.scala
+++ b/src/sbt-test/mecha/mecha-super-repo/examples-core-utils/src/main/scala/org/stormenroute/mecha/Utils.scala
@@ -1,0 +1,6 @@
+package org.stormenroute.mecha
+
+object Utils {
+
+  def multiply(x: Int): Int = x * x * x
+}

--- a/src/sbt-test/mecha/mecha-super-repo/project/Build.scala
+++ b/src/sbt-test/mecha/mecha-super-repo/project/Build.scala
@@ -1,0 +1,58 @@
+
+import org.stormenroute.mecha._
+import sbt.Keys._
+import sbt._
+
+object MechaSuperRepoBuild extends MechaSuperBuild {
+
+  lazy val mechaSuperRepoSettings = Defaults.defaultSettings ++
+    defaultMechaSuperSettings ++ Seq(
+    name := superName,
+    scalaVersion := "2.11.4",
+    version := "0.1.0-SNAPSHOT",
+    organization := "com.storm-enroute",
+    libraryDependencies ++= Seq(),
+
+    TaskKey[Unit]("checkApp") := {
+      val superRepoDir = {
+        val path = file(".").getAbsoluteFile.getParentFile.getAbsolutePath
+        if (path.startsWith("/")) path
+        else s"/$path"
+      }
+
+      val proj = s"""project {file:$superRepoDir/examples-application/}"""
+
+      val pluginVersion = sys.props("plugin.version")
+      println(s"pluginVersion: $pluginVersion")
+
+      val process = sbt.Process(
+        Seq("sbt", s"""-Dplugin.version=$pluginVersion""", proj, "assembly", "check"),
+        file(".")
+      )
+      val exitCode = (process!<)
+      if (exitCode != 0) {
+        sys.error(s"Nonzero exit value: $exitCode")
+      }
+      ()
+    },
+
+    TaskKey[Unit]("checkAppDirectly") := {
+      val pluginVersion = sys.props("plugin.version")
+      println(s"pluginVersion: $pluginVersion")
+
+      val process = sbt.Process(
+        Seq("sbt", s"""-Dplugin.version=$pluginVersion""", "clean", "assembly", "check"),
+        file("examples-application")
+      )
+      val exitCode = (process!<)
+      if (exitCode != 0) {
+        sys.error(s"Nonzero exit value: $exitCode")
+      }
+      ()
+    }
+  )
+   
+  val superName = "mecha-super-repo"
+  val superDirectory = file(".")
+  val superSettings = mechaSuperRepoSettings
+}

--- a/src/sbt-test/mecha/mecha-super-repo/project/plugins.sbt
+++ b/src/sbt-test/mecha/mecha-super-repo/project/plugins.sbt
@@ -1,0 +1,8 @@
+
+resolvers += "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository"
+
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.storm-enroute" % "mecha" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/mecha/mecha-super-repo/repos.conf
+++ b/src/sbt-test/mecha/mecha-super-repo/repos.conf
@@ -1,0 +1,18 @@
+
+mecha-super-repo {
+  dir = "."
+  origin = ""
+  mirrors = []
+}
+
+examples-core-utils {
+  dir = "examples-core-utils"
+  origin = ""
+  mirrors = []
+}
+
+examples-application {
+  dir = "examples-application"
+  origin = ""
+  mirrors = []
+}

--- a/src/sbt-test/mecha/mecha-super-repo/test
+++ b/src/sbt-test/mecha/mecha-super-repo/test
@@ -1,0 +1,11 @@
+# check super-repo
+> mecha-ls
+> projects
+
+# check application source-level dependencies
+
+# when run sbt inside super-repo
+> checkApp
+
+# when run sbt directly in the app folder within super-repo
+> checkAppDirectly

--- a/src/sbt-test/mecha/standalone-repos/build.sbt
+++ b/src/sbt-test/mecha/standalone-repos/build.sbt
@@ -1,0 +1,35 @@
+
+lazy val `standalone-repos` = (project in file("."))
+  .settings(
+    name := "standalone-repos",
+    scalaVersion := "2.11.4",
+    version := "0.1.0-SNAPSHOT",
+    organization := "com.storm-enroute",
+
+    TaskKey[Unit]("publishUtilsLocal") := {
+      val process = sbt.Process(
+        Seq("sbt", "publishLocal"),
+        file("examples-core-utils")
+      )
+      val exitCode = (process!<)
+      if (exitCode != 0) {
+        sys.error(s"Nonzero exit value: $exitCode")
+      }
+      ()
+    },
+
+    TaskKey[Unit]("checkApp") := {
+      val pluginVersion = sys.props("plugin.version")
+      println(s"pluginVersion: $pluginVersion")
+
+      val process = sbt.Process(
+        Seq("sbt", s"""-Dplugin.version=$pluginVersion""", "assembly", "check"),
+        file("examples-application")
+      )
+      val exitCode = (process!<)
+      if (exitCode != 0) {
+        sys.error(s"Nonzero exit value: $exitCode")
+      }
+      ()
+    }
+  )

--- a/src/sbt-test/mecha/standalone-repos/examples-application/build.sbt
+++ b/src/sbt-test/mecha/standalone-repos/examples-application/build.sbt
@@ -1,0 +1,15 @@
+
+lazy val `examples-application` = ExamplesApplicationBuild.examplesApplication
+  .settings(
+    assemblyJarName in assembly := "examples-application.jar",
+    TaskKey[Unit]("check") := {
+      val process = sbt.Process("java", Seq(
+        "-jar", (crossTarget.value / (assemblyJarName in assembly).value).toString)
+      )
+      val out = (process!!).trim
+      if (out != "25") {
+        sys.error("unexpected output: " + out)
+      }
+      ()
+    }
+  )

--- a/src/sbt-test/mecha/standalone-repos/examples-application/project/Build.scala
+++ b/src/sbt-test/mecha/standalone-repos/examples-application/project/Build.scala
@@ -1,0 +1,42 @@
+
+import org.stormenroute.mecha._
+import sbt.Keys._
+import sbt._
+
+object ExamplesApplicationBuild extends MechaProjectBuild {
+
+  lazy val examplesApplicationSettings = Defaults.coreDefaultSettings ++
+    MechaRepoPlugin.defaultSettings ++ Seq(
+    name := "examples-application",
+    scalaVersion := "2.11.4",
+    version := "0.1.0-SNAPSHOT",
+    organization := "com.storm-enroute",
+
+    // include dependencies as usual
+    libraryDependencies ++= runtimeDependencies.value,
+
+    // AT THE END of settings
+    // exclude dependencies based on super-repo, if any
+    libraryDependencies --= excludeSuperRepoDependencies.value
+  )
+
+  // put super-repo projects dependencies here
+  val superRepoProjectsDependencies: Seq[(String, String, Option[String])] = Seq(
+    // (repo, project, configuration)
+    ("examples-core-utils", "examples-core-utils", None)
+  )
+
+  // you can put ALL usual project dependencies here
+  val runtimeDependencies: Def.Initialize[Seq[ModuleID]] = Def.setting(Seq(
+    Def.setting("com.storm-enroute" %% "examples-core-utils" % "0.1.0-SNAPSHOT").value,
+    Def.setting("org.scalatest" %% "scalatest" % "3.0.1" % "test").value
+  ))
+
+  val repoName = "examples-application"
+
+  lazy val examplesApplication: Project = Project(
+    "examples-application",
+    file("."),
+    settings = examplesApplicationSettings
+  ) dependsOnSuperRepo
+}

--- a/src/sbt-test/mecha/standalone-repos/examples-application/project/assembly.sbt
+++ b/src/sbt-test/mecha/standalone-repos/examples-application/project/assembly.sbt
@@ -1,0 +1,2 @@
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/src/sbt-test/mecha/standalone-repos/examples-application/project/build.properties
+++ b/src/sbt-test/mecha/standalone-repos/examples-application/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.17

--- a/src/sbt-test/mecha/standalone-repos/examples-application/project/plugins.sbt
+++ b/src/sbt-test/mecha/standalone-repos/examples-application/project/plugins.sbt
@@ -1,0 +1,8 @@
+
+resolvers += "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository"
+
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.storm-enroute" % "mecha" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/mecha/standalone-repos/examples-application/src/main/scala/org/stormenroute/mecha/App.scala
+++ b/src/sbt-test/mecha/standalone-repos/examples-application/src/main/scala/org/stormenroute/mecha/App.scala
@@ -1,0 +1,8 @@
+package org.stormenroute.mecha
+
+object App {
+
+  def main(args: Array[String]): Unit = {
+    println(Utils.multiply(5))
+  }
+}

--- a/src/sbt-test/mecha/standalone-repos/examples-core-utils/build.sbt
+++ b/src/sbt-test/mecha/standalone-repos/examples-core-utils/build.sbt
@@ -1,0 +1,8 @@
+
+lazy val `examples-core-utils` = (project in file("."))
+  .settings(
+    name := "examples-core-utils",
+    scalaVersion := "2.11.4",
+    version := "0.1.0-SNAPSHOT",
+    organization := "com.storm-enroute"
+  )

--- a/src/sbt-test/mecha/standalone-repos/examples-core-utils/project/build.properties
+++ b/src/sbt-test/mecha/standalone-repos/examples-core-utils/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.17

--- a/src/sbt-test/mecha/standalone-repos/examples-core-utils/src/main/scala/org/stormenroute/mecha/Utils.scala
+++ b/src/sbt-test/mecha/standalone-repos/examples-core-utils/src/main/scala/org/stormenroute/mecha/Utils.scala
@@ -1,0 +1,6 @@
+package org.stormenroute.mecha
+
+object Utils {
+
+  def multiply(x: Int): Int = x * x
+}

--- a/src/sbt-test/mecha/standalone-repos/test
+++ b/src/sbt-test/mecha/standalone-repos/test
@@ -1,0 +1,5 @@
+# first - publish utils artifact
+> publishUtilsLocal
+
+# check that app uses the published utils artifact
+> checkApp


### PR DESCRIPTION
In this pull request i've added support for defining super-repo dependencies in the source code instead of using `dependencies.conf` file.

The benefits are:
* all the dependencies for the project can be defined in one place
* any kind of scala dependency can be used, including `%%%` cross-rpoject dependencies (fixes #6)

All the main logic are written in the `MechaProjectBuild` trait, which can be used as a replacement for the `MechaRepoBuild`. Example usage with the detailed description is added to the updated `README.md`.

Also, i've introduced  [integration/sbt-tests](https://www.scala-sbt.org/0.13/docs/Testing-sbt-plugins.html) to test the new code. They can be executed by running the following command:
```bash
sbt publishM2 scripted
```
All three cases are tested:
* **standalone/without super-repo** - application using regular artifact
* **with super-repo, running `sbt` in super-repo folder** and using `project {file:/.../}` command to switch to the application and check it uses dependency from super-repo
* **with super-repo, running `sbt` directly in the app folder** and check it uses dependency from super-repo